### PR TITLE
fix code->code = (ngx_http_replace_script_code_pt)

### DIFF
--- a/src/ngx_http_replace_script.c
+++ b/src/ngx_http_replace_script.c
@@ -345,7 +345,7 @@ ngx_http_replace_script_add_copy_code(ngx_http_replace_script_compile_t *sc,
         return NGX_ERROR;
     }
 
-    code->code = (ngx_http_replace_script_code_pt)
+    code->code = (ngx_http_replace_script_code_pt)(void *)
                  ngx_http_replace_script_copy_len_code;
     code->len = len;
 
@@ -417,7 +417,7 @@ ngx_http_replace_script_add_capture_code(ngx_http_replace_script_compile_t *sc,
         return NGX_ERROR;
     }
 
-    code->code = (ngx_http_replace_script_code_pt)
+    code->code = (ngx_http_replace_script_code_pt)(void *)
                  ngx_http_replace_script_copy_capture_len_code;
     code->n = 2 * n;
 
@@ -609,7 +609,7 @@ ngx_http_replace_script_add_var_code(ngx_http_replace_script_compile_t *sc,
         return NGX_ERROR;
     }
 
-    code->code = (ngx_http_replace_script_code_pt)
+    code->code = (ngx_http_replace_script_code_pt)(void *)
                  ngx_http_replace_script_copy_var_len_code;
 
     code->index = (uintptr_t) index;


### PR DESCRIPTION
when use gcc 8, report error:

**ENV:**

```/ # gcc --version
gcc (Alpine 8.3.0) 8.3.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

**Error info:**
```
cc -c -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g   -I src/core -I src/event -I src/event/modules -I src/os/unix -I ../nginx_upstream_check_module -I /usr/local/src/openssl-1.1.0l/.openssl/include -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/stream \
        -o objs/addon/src/ngx_http_replace_script.o \
        ../replace-filter-nginx-module/src/ngx_http_replace_script.c
../replace-filter-nginx-module/src/ngx_http_replace_script.c: In function 'ngx_http_replace_script_add_copy_code':
../replace-filter-nginx-module/src/ngx_http_replace_script.c:348:18: error: cast between incompatible function types from 'size_t (*)(ngx_http_replace_script_engine_t *)' {aka 'long unsigned int (*)(struct <anonymous> *)'} to 'void (*)(ngx_http_replace_script_engine_t *)' {aka 'void (*)(struct <anonymous> *)'} [-Werror=cast-function-type]
     code->code = (ngx_http_replace_script_code_pt)
                  ^
../replace-filter-nginx-module/src/ngx_http_replace_script.c: In function 'ngx_http_replace_script_add_capture_code':
../replace-filter-nginx-module/src/ngx_http_replace_script.c:420:18: error: cast between incompatible function types from 'size_t (*)(ngx_http_replace_script_engine_t *)' {aka 'long unsigned int (*)(struct <anonymous> *)'} to 'void (*)(ngx_http_replace_script_engine_t *)' {aka 'void (*)(struct <anonymous> *)'} [-Werror=cast-function-type]
     code->code = (ngx_http_replace_script_code_pt)
                  ^
../replace-filter-nginx-module/src/ngx_http_replace_script.c: In function 'ngx_http_replace_script_add_var_code':
../replace-filter-nginx-module/src/ngx_http_replace_script.c:612:18: error: cast between incompatible function types from 'size_t (*)(ngx_http_replace_script_engine_t *)' {aka 'long unsigned int (*)(struct <anonymous> *)'} to 'void (*)(ngx_http_replace_script_engine_t *)' {aka 'void (*)(struct <anonymous> *)'} [-Werror=cast-function-type]
     code->code = (ngx_http_replace_script_code_pt)
                  ^
cc1: all warnings being treated as errors
make[1]: *** [objs/Makefile:1608: objs/addon/src/ngx_http_replace_script.o] Error 1
make[1]: Leaving directory '/opt/Apps/nginx-1.17.5'
make: *** [Makefile:8: build] Error 2
```

so， update  `code->code = (ngx_http_replace_script_code_pt)...` to `code->code = (ngx_http_replace_script_code_pt)(void *)...`